### PR TITLE
Fix pipette hover crash on fresh pipette frame cache.

### DIFF
--- a/vspreview/toolbars/pipette/toolbar.py
+++ b/vspreview/toolbars/pipette/toolbar.py
@@ -131,10 +131,13 @@ class PipetteToolbar(AbstractToolbar):
         else:
             cache = self._curr_frame_cache[self.main.current_output]
 
-        if cache[1] is None or cache[0] != self.main.current_output.last_showed_frame:
+        last_showed_frame = int(self.main.current_output.last_showed_frame)
+        if cache[1] is None or cache[0] != last_showed_frame:
             cache = (
-                int(self.main.current_output.last_showed_frame),
-                self.outputs[self.main.current_output].get_frame(cache[0])
+                last_showed_frame,
+                self.outputs[self.main.current_output].get_frame(
+                    last_showed_frame
+                )
             )
 
         return cache[1]

--- a/vspreview/toolbars/pipette/toolbar.py
+++ b/vspreview/toolbars/pipette/toolbar.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import ctypes
 from math import ceil, floor, log
 from struct import unpack
-from typing import Generator, Tuple, cast
+from typing import Generator, Tuple, Union, cast
 from weakref import WeakKeyDictionary
 
 import vapoursynth as vs


### PR DESCRIPTION
The last code cleanup (da1bfe6456f01d8473fe7b0c3f978f65b7a7c3e3) resulted in referencing `cache[0]` before it was populated.