### PR TITLE
Document filename variables used in "save frame" menu, and fix its tooltip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pip install -U git+https://github.com/Irrational-Encoding-Wizardry/vs-preview.gi
 
 It can be used by running `vspreview script.vpy` or your preferred way in [your IDE](#ide-integration).
 
-[Keyboard Shortcut](https://github.com/Irrational-Encoding-Wizardry/vs-preview/blob/master/docs/shortcuts.md)
+[Keyboard Shortcuts](https://github.com/Irrational-Encoding-Wizardry/vs-preview/blob/master/docs/shortcuts.md)
+[Saved Frame Filename Variables](https://github.com/Irrational-Encoding-Wizardry/vs-preview/blob/master/docs/save_frame_placeholders.md)
 
 # IDE Integration
 

--- a/docs/save_frame_placeholders.md
+++ b/docs/save_frame_placeholders.md
@@ -1,0 +1,18 @@
+#Save frame placeholders
+|Placeholder    |Description|Example|
+|---------------|-|-|
+|{format}       |Pixel format of the frame|YUV420P10|
+|{fps_den}      |FPS denominator|1001|
+|{fps_num}      |FPS numerator|24000|
+|{frame}        |Current frame number (zero-indexed)|55369|
+|{height}       |Height of frame in pixels|960|
+|{index}        |Video node number (zero-indexed)|0|
+|{matrix}*      |Matrix coefficients of frame|BT709|
+|{primaries}*   |Color primaries of frame|BT709|
+|{range}*       |Color range of frame|Limited|
+|{script_name}  |Script name without extension|the-outfit-2022|
+|{total_frames} |Number of frames in clip|151008|
+|{transfer}*    |Transfer characteristics of frame|BT709|
+|{width}        |Width of frame in pixels|1920|
+
+*currently crashes vspreview when used so example may be malformed

--- a/vspreview/toolbars/misc/toolbar.py
+++ b/vspreview/toolbars/misc/toolbar.py
@@ -63,10 +63,10 @@ class MiscToolbar(AbstractToolbar):
 
         self.save_template_lineedit = LineEdit(
             self.settings.SAVE_TEMPLATE, self, tooltip=(
-                r'Available placeholders: {format}, {fps_den}, {fps_num}, {frame},\n'
-                r' {height}, {index}, {matrix}, {primaries}, {range},\n'
-                r' {script_name}, {total_frames}, {transfer}, {width}.\n'
-                r' Frame props can be accessed as well using their names.\n'
+                '''Available placeholders: {format}, {fps_den}, {fps_num}, {frame},
+{height}, {index}, {matrix}, {primaries}, {range},
+{script_name}, {total_frames}, {transfer}, {width}.
+Frame props can be accessed as well using their names.'''
             )
         )
 


### PR DESCRIPTION
Please check that the example outputs of the asterisked variables are correctly formed, I can't get a proper output from them since I can't debug why they crash vspreview :P