### PR TITLE
Fix a crash that occurs when opening a second file within a workspace

### DIFF
--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -576,7 +576,7 @@ class MainWindow(AbstractMainWindow):
                 with open(icc_path, 'rb') as icc:
                     self.display_profile = QColorSpace.fromIccProfile(icc.read())
 
-        if hasattr(self, 'current_output') and self.display_profile is not None:
+        if hasattr(self, 'current_output') and self.current_output is not None and self.display_profile is not None:
             self.switch_frame(self.current_output.last_showed_frame)
 
     def show_message(self, message: str) -> None:


### PR DESCRIPTION
I'm not certain exactly what triggered this scenario, but the situation that occurred is that `self.current_output` is an attribute on the class that `self` is, and that attribute is set to `None`. `hasattr` returns `True` because there is an attribute on `self` called `current_output`, even though it is `None`.