### PR TITLE
Add --frame CLI arg for seeking to a specified frame on load

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "python.linting.flake8Enabled": true,
     "python.linting.flake8Args": ["--max-line-length=120", "--ignore=None"],
     "python.linting.pydocstyleArgs": ["--ignore=None"],
-    "python.analysis.memory.keepLibraryAst": true
+    "python.analysis.memory.keepLibraryAst": true,
+    "python.formatting.provider": "autopep8"
   }
   

--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -279,8 +279,8 @@ class AbstractMainWindow(ExtendedMainWindow, QAbstractYAMLObjectSingleton):
 
     @abstractmethod
     def load_script(
-        self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False
-    ) -> None:
+            self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False,
+            start_frame: int = 0) -> None:
         raise NotImplementedError
 
     @abstractmethod

--- a/vspreview/init.py
+++ b/vspreview/init.py
@@ -99,8 +99,9 @@ def main() -> None:
 
     app = Application(sys.argv)
     main_window = MainWindow(Path(os.getcwd()) if args.preserve_cwd else script_path.parent)
-    main_window.load_script(script_path, [tuple(a.split('=', maxsplit=1))
-                            for a in args.arg or []], False, start_frame=args.frame or 0)
+    main_window.load_script(
+        script_path, [tuple(a.split('=', maxsplit=1)) for a in args.arg or []], False, start_frame=args.frame or 0
+    )
     main_window.show()
 
     app.exec_()

--- a/vspreview/init.py
+++ b/vspreview/init.py
@@ -67,6 +67,7 @@ def main() -> None:
     parser.add_argument(
         '--arg', '-a', type=str, action='append', metavar='key=value', help='Argument to pass to the script environment'
     )
+    parser.add_argument('-f', '--frame', type=int, help='Frame to load initially (defaults to 0)')
     parser.add_argument(
         '--vscode-setup', type=str, choices=['override', 'append', 'ignore'], nargs='?', const='append',
         help='Installs launch settings in cwd\'s .vscode'
@@ -98,7 +99,8 @@ def main() -> None:
 
     app = Application(sys.argv)
     main_window = MainWindow(Path(os.getcwd()) if args.preserve_cwd else script_path.parent)
-    main_window.load_script(script_path, [tuple(a.split('=', maxsplit=1)) for a in args.arg or []], False)
+    main_window.load_script(script_path, [tuple(a.split('=', maxsplit=1))
+                            for a in args.arg or []], False, start_frame=args.frame or 0)
     main_window.show()
 
     app.exec_()

--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -193,8 +193,8 @@ class MainWindow(AbstractMainWindow):
         return stylesheet + 'QGraphicsView { border: 0px; padding: 0px; }'
 
     def load_script(
-        self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False
-    ) -> None:
+            self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False,
+            start_frame: int = 0) -> None:
         self.external_args = external_args or []
 
         self.toolbars.playback.stop()
@@ -276,6 +276,7 @@ class MainWindow(AbstractMainWindow):
 
         if not reloading:
             self.switch_output(self.settings.output_index)
+            self.switch_frame(Frame(start_frame))
 
     @set_status_label('Loading...')
     def load_storage(self) -> None:

--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -193,8 +193,9 @@ class MainWindow(AbstractMainWindow):
         return stylesheet + 'QGraphicsView { border: 0px; padding: 0px; }'
 
     def load_script(
-            self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False,
-            start_frame: int = 0) -> None:
+        self, script_path: Path, external_args: List[Tuple[str, str]] | None = None, reloading: bool = False,
+        start_frame: int = 0
+    ) -> None:
         self.external_args = external_args or []
 
         self.toolbars.playback.stop()


### PR DESCRIPTION
I had a use case for this as part of a script to find the frame with the most out-of-range pixels in a video, and then display it. My hope is that it might be useful to someone else as well.