### PR TITLE
bump tag exists action version

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check if version exists
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@v1.1.0
         id: tagcheck
         with:
           tag: ${{ env.CURR_VER }}


### PR DESCRIPTION
This PR bumps the tag-exists-action version to v1.1.0 which should get rid of _some of_ [these warnings](https://github.com/Irrational-Encoding-Wizardry/vs-preview/actions/runs/3264358938):
![image](https://user-images.githubusercontent.com/4502154/198848288-52c34190-a361-41f7-b634-05d79e635ce2.png)
