### PR TITLE
Fix crash when Frame Props dialog is cleared during output switching.

### DIFF
--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -101,9 +101,18 @@ class ExtendedLayout(QBoxLayout):
 
     def clear(self) -> None:
         for i in reversed(range(self.count())):
-            widget = self.itemAt(i).widget()
-            self.removeWidget(widget)
-            widget.setParent(None)  # type: ignore
+            item = self.itemAt(i)
+            widget = item.widget()
+            self.removeItem(item)
+            if widget:
+                # removeItem only takes it out of the layout. The widget
+                # still exists inside its parent widget.
+                widget.deleteLater()
+            else:
+                # Clear and delete sub-layouts
+                if isinstance(item, ExtendedLayout):
+                    item.clear()
+                item.deleteLater()
 
     @staticmethod
     def stretch(amount: int | None) -> Stretch:


### PR DESCRIPTION
Crash was due to sub-layouts being included in the layout's items being iterated and sub-layouts don't contain a singular widget. Sub-layouts are now removed, cleared, and deleted. Widgets removed from the layout are deleted as before.

`widget.deleteLater()` will remove the parent relationship automatically so `widget.setParent(None)` is unnecessary.

Fixes Irrational-Encoding-Wizardry/vs-preview#63