### PR TITLE
Fix recent Scening toolbar and workflow issues

### DIFF
--- a/vspreview/main/timeline.py
+++ b/vspreview/main/timeline.py
@@ -269,7 +269,7 @@ class Timeline(QWidget):
             for notch in notches:
                 line = notch.line
                 if line.x1() - 0.5 <= event.pos().x() <= line.x1() + 0.5:
-                    QToolTip.showText(event.globalPosition(), notch.label)
+                    QToolTip.showText(event.globalPosition().toPoint(), notch.label)
                     return
 
     def resizeEvent(self, event: QResizeEvent) -> None:

--- a/vspreview/toolbars/scening/dialog.py
+++ b/vspreview/toolbars/scening/dialog.py
@@ -85,9 +85,8 @@ class SceningListDialog(ExtendedDialog):
                 selection.select(index, index)
         self.tableview.selectionModel().select(
             selection,
-            QItemSelectionModel.SelectionFlags(
-                QItemSelectionModel.Rows + QItemSelectionModel.ClearAndSelect
-            )
+            QItemSelectionModel.SelectionFlag.Rows
+            | QItemSelectionModel.SelectionFlag.ClearAndSelect
         )
 
     def on_current_list_changed(self, scening_list: SceningList | None = None) -> None:

--- a/vspreview/toolbars/scening/dialog.py
+++ b/vspreview/toolbars/scening/dialog.py
@@ -121,8 +121,10 @@ class SceningListDialog(ExtendedDialog):
 
         frame = Frame(value)
 
-        index = self.tableview.selectionModel().selectedRows()[0]
-
+        try:
+            index = self.tableview.selectionModel().selectedRows()[0]
+        except IndexError:
+            return
         if not index.isValid():
             return
         index = index.siblingAtColumn(SceningList.END_FRAME_COLUMN)
@@ -133,9 +135,10 @@ class SceningListDialog(ExtendedDialog):
     def on_end_time_changed(self, time: Time) -> None:
         if self.tableview.selectionModel() is None:
             return
-
-        index = self.tableview.selectionModel().selectedRows()[0]
-
+        try:
+            index = self.tableview.selectionModel().selectedRows()[0]
+        except IndexError:
+            return
         if not index.isValid():
             return
         index = index.siblingAtColumn(SceningList.END_TIME_COLUMN)
@@ -146,9 +149,10 @@ class SceningListDialog(ExtendedDialog):
     def on_label_changed(self, text: str) -> None:
         if self.tableview.selectionModel() is None:
             return
-
-        index = self.tableview.selectionModel().selectedRows()[0]
-
+        try:
+            index = self.tableview.selectionModel().selectedRows()[0]
+        except IndexError:
+            return
         if not index.isValid():
             return
         index = self.scening_list.index(index.row(), SceningList.LABEL_COLUMN)

--- a/vspreview/toolbars/scening/toolbar.py
+++ b/vspreview/toolbars/scening/toolbar.py
@@ -318,7 +318,7 @@ class SceningToolbar(AbstractToolbar):
     def on_add_single_frame_clicked(self, checked: bool | None = None) -> None:
         if self.current_list is None:
             self.on_add_list_clicked()
-        cast(SceningList, self.current_list).add(self.main.current_output.last_showed_frame)
+        cast(SceningList, self.current_list).add(self.main.current_output.last_showed_frame, label=self.label_lineedit.text())
         self.check_remove_export_possibility()
 
     def on_add_to_list_clicked(self, checked: bool | None = None) -> None:


### PR DESCRIPTION
This fixes the following crash scenarios:
- Hovering cursor on timeline scene notch.
- Browsing to new frames while there are listed scenes.
- Editing scene properties in the scene list dialog despite no scene selected.

It also fixes the scene label not being added for single-frame scenes. Some of these issues were caused by the PyQt6 refactor, but a couple were present beforehand.

Fixes Irrational-Encoding-Wizardry/vs-preview#62.