### PR TITLE
Fix force-checking the P-frame checkbox

### DIFF
--- a/vspreview/toolbars/comp/toolbar.py
+++ b/vspreview/toolbars/comp/toolbar.py
@@ -329,7 +329,7 @@ class CompToolbar(AbstractToolbar):
                 if self_s == 'I':
                     el = self.pic_type_button_I
                     oth = (self.pic_type_button_P, self.pic_type_button_B)
-                elif self_s == 'I':
+                elif self_s == 'P':
                     el = self.pic_type_button_P
                     oth = (self.pic_type_button_I, self.pic_type_button_B)
                 else:


### PR DESCRIPTION
This patch adds a missing `elif` condition for the P-frame checkbox. Previously with only P-frames checked, unchecking it would result in the B-frame checkbox being forced-checked.