### PR TITLE
Make plugins able to have notches

### DIFF
--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -384,7 +384,6 @@ class AbstractToolbar(ExtendedWidget, NotchProvider):
 
     def __init__(self, main: MainWindow, settings: QWidget | None = None) -> None:
         super().__init__(main.central_widget)
-        self.init_notches(main)
 
         if settings is None:
             from vstools.exceptions import CustomValueError
@@ -398,7 +397,6 @@ class AbstractToolbar(ExtendedWidget, NotchProvider):
         self.main.app_settings.addTab(settings, self.name)
         self.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
 
-
         self.toggle_button = PushButton(
             self.name, self, checkable=True, clicked=self.on_toggle
         )
@@ -406,6 +404,8 @@ class AbstractToolbar(ExtendedWidget, NotchProvider):
 
         self.setVisible(False)
         self.visibility = False
+
+        self.init_notches(self.main)
 
     def setup_ui(self) -> None:
         self.hlayout = HBoxLayout(self)

--- a/vspreview/core/abstracts.py
+++ b/vspreview/core/abstracts.py
@@ -352,7 +352,7 @@ class AbstractToolbarSettings(ExtendedWidget, QYAMLObjectSingleton):
                 ...
 
 
-class NotchProvider:
+class NotchProvider(QABC):
     notches_changed = pyqtSignal(ExtendedWidget)
 
     def init_notches(self, main: MainWindow = ...) -> None:
@@ -362,11 +362,13 @@ class NotchProvider:
         from .custom import Notches
         return Notches()
 
+    @property
+    @abstractmethod
     def is_notches_visible(self) -> bool:
-        return False
+        ...
 
 
-class AbstractToolbar(ExtendedWidget, NotchProvider, QABC):
+class AbstractToolbar(ExtendedWidget, NotchProvider):
     _no_visibility_choice = False
     storable_attrs = tuple[str, ...]()
     class_storable_attrs = tuple[str, ...](('settings', 'visibility'))
@@ -427,8 +429,9 @@ class AbstractToolbar(ExtendedWidget, NotchProvider, QABC):
     def on_current_output_changed(self, index: int, prev_index: int) -> None:
         pass
 
+    @property
     def is_notches_visible(self) -> bool:
-        return self.isVisible()
+        return self.visibility
 
     def resize_main_window(self, expanding: bool) -> None:
         if self.main.windowState() in {Qt.WindowState.WindowMaximized, Qt.WindowState.WindowFullScreen}:

--- a/vspreview/main/timeline.py
+++ b/vspreview/main/timeline.py
@@ -122,7 +122,7 @@ class Timeline(QWidget):
             )
 
             for provider, notches in self.notches.items():
-                if not provider.is_notches_visible():
+                if not provider.is_notches_visible:
                     continue
 
                 for notch in notches:
@@ -183,7 +183,7 @@ class Timeline(QWidget):
         painter.fillRect(self.scroll_rect, Qt.GlobalColor.gray)
 
         for provider, notches in self.notches.items():
-            if not provider.is_notches_visible():
+            if not provider.is_notches_visible:
                 continue
 
             for notch in notches:
@@ -213,7 +213,7 @@ class Timeline(QWidget):
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         super().mouseMoveEvent(event)
         for provider, notches in self.notches.items():
-            if not provider.is_notches_visible():
+            if not provider.is_notches_visible:
                 continue
             for notch in notches:
                 line = notch.line

--- a/vspreview/main/timeline.py
+++ b/vspreview/main/timeline.py
@@ -7,7 +7,7 @@ from PyQt6.QtCore import QEvent, QLineF, QRectF, Qt, pyqtSignal
 from PyQt6.QtGui import QMouseEvent, QMoveEvent, QPainter, QPaintEvent, QPalette, QPen, QResizeEvent
 from PyQt6.QtWidgets import QApplication, QToolTip, QWidget
 
-from ..core import AbstractToolbar, AbstractYAMLObject, Frame, Notch, Notches, Time, VideoOutput, main_window
+from ..core import NotchProvider, AbstractYAMLObject, Frame, Notch, Notches, Time, VideoOutput, main_window
 from ..utils import strfdelta
 
 __all__ = [
@@ -68,7 +68,7 @@ class Timeline(QWidget):
         # False means that only cursor position'll be recalculated
         self.need_full_repaint = True
 
-        self.toolbars_notches = dict[AbstractToolbar, Notches]()
+        self.notches = dict[NotchProvider, Notches]()
 
         self.setAttribute(Qt.WidgetAttribute.WA_OpaquePaintEvent)
         self.setMouseTracking(True)
@@ -121,8 +121,8 @@ class Timeline(QWidget):
                 self.rect_f.width(), self.scroll_height
             )
 
-            for toolbar, notches in self.toolbars_notches.items():
-                if not toolbar.is_notches_visible():
+            for provider, notches in self.notches.items():
+                if not provider.is_notches_visible():
                     continue
 
                 for notch in notches:
@@ -182,8 +182,8 @@ class Timeline(QWidget):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, False)
         painter.fillRect(self.scroll_rect, Qt.GlobalColor.gray)
 
-        for toolbar, notches in self.toolbars_notches.items():
-            if not toolbar.is_notches_visible():
+        for provider, notches in self.notches.items():
+            if not provider.is_notches_visible():
                 continue
 
             for notch in notches:
@@ -212,8 +212,8 @@ class Timeline(QWidget):
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         super().mouseMoveEvent(event)
-        for toolbar, notches in self.toolbars_notches.items():
-            if not toolbar.is_notches_visible():
+        for provider, notches in self.notches.items():
+            if not provider.is_notches_visible():
                 continue
             for notch in notches:
                 line = notch.line
@@ -233,12 +233,14 @@ class Timeline(QWidget):
 
         return super().event(event)
 
-    def update_notches(self, toolbar: AbstractToolbar | None = None) -> None:
-        if toolbar is not None:
-            self.toolbars_notches[toolbar] = toolbar.get_notches()
-        if toolbar is None:
+    def update_notches(self, provider: NotchProvider | None = None) -> None:
+        if provider is not None:
+            self.notches[provider] = provider.get_notches()
+        else:
             for t in self.main.toolbars:
-                self.toolbars_notches[t] = t.get_notches()
+                self.notches[t] = t.get_notches()
+            for t in self.main.plugins:
+                self.notches[t] = t.get_notches()
         self.full_repaint()
 
     @property

--- a/vspreview/plugins/__init__.py
+++ b/vspreview/plugins/__init__.py
@@ -50,6 +50,9 @@ class Plugins(AbstractYAMLObjectSingleton):
         for name, plugin in self.plugins.items():
             plugin.setObjectName(f'Plugins.{name}')
 
+            if not plugin._visible_in_tab:
+                continue
+
             self.plugins_tab.addTab(plugin, plugin._plugin_name)
 
     def on_current_frame_changed(self, frame: Frame) -> None:

--- a/vspreview/plugins/__init__.py
+++ b/vspreview/plugins/__init__.py
@@ -43,17 +43,21 @@ class Plugins(AbstractYAMLObjectSingleton):
         ]
 
         self.plugins = dict[str, AbstractPlugin]({
-            name: self.file_to_plugin(name)(main)
+            name: self.file_to_plugin(name)(main, -1)
             for name in self.plugin_names
         })
 
+        i = 0
         for name, plugin in self.plugins.items():
             plugin.setObjectName(f'Plugins.{name}')
 
             if not plugin._visible_in_tab:
                 continue
 
+            plugin.index = i
+
             self.plugins_tab.addTab(plugin, plugin._plugin_name)
+            i += 1
 
     def on_current_frame_changed(self, frame: Frame) -> None:
         tab_idx = self.plugins_tab.currentIndex()

--- a/vspreview/plugins/abstract.py
+++ b/vspreview/plugins/abstract.py
@@ -19,7 +19,7 @@ class AbstractPlugin(ExtendedWidgetBase, NotchProvider):
     _plugin_name: ClassVar[str]
     _visible_in_tab: ClassVar[bool] = True
 
-    def __init__(self, main: MainWindow) -> None:
+    def __init__(self, main: MainWindow, index: int) -> None:
         try:
             super().__init__(main)
             self.init_notches(main)
@@ -29,6 +29,7 @@ class AbstractPlugin(ExtendedWidgetBase, NotchProvider):
             raise e
 
         self.main = main
+        self.index = index
 
         self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
 

--- a/vspreview/plugins/abstract.py
+++ b/vspreview/plugins/abstract.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from PyQt6.QtWidgets import QSizePolicy
 
-from ..core import ExtendedWidgetBase, Frame
+from ..core import ExtendedWidgetBase, Frame, NotchProvider
 
 if TYPE_CHECKING:
     from ..main import MainWindow
@@ -15,12 +15,13 @@ __all__ = [
 ]
 
 
-class AbstractPlugin(ExtendedWidgetBase):
+class AbstractPlugin(ExtendedWidgetBase, NotchProvider):
     _plugin_name: ClassVar[str]
 
     def __init__(self, main: MainWindow) -> None:
         try:
             super().__init__(main)
+            self.init_notches(main)
         except TypeError as e:
             print('\tMake sure you\'re inheriting a QWidget!\n')
 

--- a/vspreview/plugins/abstract.py
+++ b/vspreview/plugins/abstract.py
@@ -47,3 +47,7 @@ class AbstractPlugin(ExtendedWidgetBase, NotchProvider):
 
     def on_current_output_changed(self, index: int, prev_index: int) -> None:
         ...
+
+    @property
+    def is_notches_visible(self) -> bool:
+        return (not self._visible_in_tab) or self.index == self.main.plugins.plugins_tab.currentIndex()

--- a/vspreview/plugins/abstract.py
+++ b/vspreview/plugins/abstract.py
@@ -17,6 +17,7 @@ __all__ = [
 
 class AbstractPlugin(ExtendedWidgetBase, NotchProvider):
     _plugin_name: ClassVar[str]
+    _visible_in_tab: ClassVar[bool] = True
 
     def __init__(self, main: MainWindow) -> None:
         try:

--- a/vspreview/toolbars/scening/toolbar.py
+++ b/vspreview/toolbars/scening/toolbar.py
@@ -217,7 +217,8 @@ class SceningToolbar(AbstractToolbar):
             self.check_add_to_list_possibility()
             self.check_remove_export_possibility()
 
-        self.status_label.setVisible(self.is_notches_visible())
+        self.status_label.setVisible(self.is_notches_visible)
+
         super().on_toggle(new_state)
 
     def on_current_output_changed(self, index: int, prev_index: int) -> None:
@@ -254,6 +255,7 @@ class SceningToolbar(AbstractToolbar):
             return self.items_combobox.setCurrentIndex(index)
         raise IndexError
 
+    @property
     def is_notches_visible(self) -> bool:
         return self.always_show_scene_marks_checkbox.isChecked() or self.toggle_button.isChecked()
 


### PR DESCRIPTION
Example:
```
from __future__ import annotations

from PyQt6.QtWidgets import QTableView
from ..core import Frame
from .abstract import AbstractPlugin
from PyQt6.QtGui import QColor
from PyQt6.QtCore import Qt

from typing import cast
from ..core import Notches,VBoxLayout, PushButton
__all__ = [
    'Plugin'
]
class Plugin(AbstractPlugin, QTableView):
    _plugin_name = 'Test notches'
    __slots__ = (
       
    )

    def on_current_frame_changed(self, frame: Frame) -> None:
        pass
    

    def get_notches(self) -> Notches:
        marks = Notches()
        marks.add(Frame(15), cast(QColor, Qt.GlobalColor.darkCyan))
        marks.add(Frame(30), cast(QColor, Qt.GlobalColor.darkCyan))

        return marks

    def is_notches_visible(self) -> bool:
        return self.isVisible()
    

    def setup_ui(self) -> None:
        VBoxLayout(self, [
            PushButton("Hello"),
        ])
```